### PR TITLE
Add Render blueprint for Node deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+services:
+  - type: web
+    name: sct-web
+    runtime: node
+    buildCommand: npm install && npm run build
+    startCommand: npm run start
+    envVars:
+      - key: NEXT_PUBLIC_SUPABASE_URL
+        previewValue: "https://your-supabase-project.supabase.co"
+      - key: NEXT_PUBLIC_SUPABASE_ANON_KEY
+        previewValue: "your-anon-public-api-key"
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        generateValue: true
+        previewValue: "optional-service-role-key"


### PR DESCRIPTION
## Summary
- add a Render blueprint configuring the app as a Node web service with npm build and start commands
- declare Supabase environment variables with preview placeholders and a generated service role secret

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd20c19524832b9332cbf4460e420c