### PR TITLE
fix: use published supabase auth helper version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "sct",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/auth-helpers-nextjs": "^0.10.0",
+        "@supabase/auth-helpers-react": "^0.4.5",
         "@supabase/supabase-js": "^2.43.0",
         "next": "14.1.0",
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@supabase/auth-helpers-nextjs": "^0.10.0",
-    "@supabase/auth-helpers-react": "^0.4.6",
+    "@supabase/auth-helpers-react": "^0.4.5",
     "@supabase/supabase-js": "^2.43.0",
     "@tanstack/react-query": "^5.32.1",
     "next": "14.1.0",


### PR DESCRIPTION
## Summary
- correct the @supabase/auth-helpers-react dependency to the latest published release
- align the lockfile with the updated dependency list so automated installs resolve successfully

## Testing
- not run (npm install is blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd3e28667c832bafa9aa85d43e5355