### PR TITLE
chore: bump supabase auth helpers react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/auth-helpers-nextjs": "^0.10.0",
-        "@supabase/auth-helpers-react": "^0.4.5",
+        "@supabase/auth-helpers-react": "^0.4.9",
         "@supabase/supabase-js": "^2.43.0",
         "next": "14.1.0",
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@supabase/auth-helpers-nextjs": "^0.10.0",
-    "@supabase/auth-helpers-react": "^0.4.5",
+    "@supabase/auth-helpers-react": "^0.4.9",
     "@supabase/supabase-js": "^2.43.0",
     "@tanstack/react-query": "^5.32.1",
     "next": "14.1.0",


### PR DESCRIPTION
## Summary
- update @supabase/auth-helpers-react dependency to the latest 0.4.x release referenced locally
- align package-lock.json entry with the updated dependency constraint

## Testing
- `npm install` *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de2cd2ad10832b9468f42a8bad378e