### PR TITLE
fix: pin @supabase/auth-helpers-react version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/auth-helpers-nextjs": "^0.10.0",
-        "@supabase/auth-helpers-react": "^0.4.9",
+        "@supabase/auth-helpers-react": "0.4.9",
         "@supabase/supabase-js": "^2.43.0",
         "next": "14.1.0",
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@supabase/auth-helpers-nextjs": "^0.10.0",
-    "@supabase/auth-helpers-react": "^0.4.9",
+    "@supabase/auth-helpers-react": "0.4.9",
     "@supabase/supabase-js": "^2.43.0",
     "@tanstack/react-query": "^5.32.1",
     "next": "14.1.0",


### PR DESCRIPTION
## Summary
- pin @supabase/auth-helpers-react to version 0.4.9 to avoid unstable installs
- align the lockfile entry with the pinned dependency version

## Testing
- npm install *(fails: npm ERR! code E403 fetching packages from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68de68667158832bba6716cdae84edab