### PR TITLE
refactor: replace Supabase React helpers with custom context

### DIFF
--- a/app/(authenticated)/eta/realtime.tsx
+++ b/app/(authenticated)/eta/realtime.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useSessionContext } from "@supabase/auth-helpers-react";
+
+import { useSupabaseContext } from "@/lib/supabase-context";
 
 interface EtaBucket {
   eta_window: string;
@@ -27,7 +28,7 @@ async function fetchEtaBuckets(supabaseUrl: string, accessToken: string) {
 }
 
 export function EtaMonitor() {
-  const { supabaseClient } = useSessionContext();
+  const { supabaseClient } = useSupabaseContext();
   const queryClient = useQueryClient();
   const supabaseUrl = useMemo(() => process.env.NEXT_PUBLIC_SUPABASE_URL, []);
 

--- a/app/(authenticated)/providers.tsx
+++ b/app/(authenticated)/providers.tsx
@@ -2,21 +2,24 @@
 
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { SessionContextProvider } from "@supabase/auth-helpers-react";
 import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
 import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
+import { SupabaseProvider } from "@/lib/supabase-context";
+
 interface ProvidersProps {
   children: ReactNode;
-  initialSession: Session;
+  initialSession: Session | null;
 }
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error("Missing Supabase environment variables. Ensure NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are set.");
+  throw new Error(
+    "Missing Supabase environment variables. Ensure NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are set.",
+  );
 }
 
 export function Providers({ children, initialSession }: ProvidersProps) {
@@ -26,8 +29,11 @@ export function Providers({ children, initialSession }: ProvidersProps) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <SessionContextProvider supabaseClient={supabase} initialSession={initialSession}>
+    <SupabaseProvider
+      supabaseClient={supabase}
+      initialSession={initialSession}
+    >
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </SessionContextProvider>
+    </SupabaseProvider>
   );
 }

--- a/app/(authenticated)/settings/notifications/preferences-form.tsx
+++ b/app/(authenticated)/settings/notifications/preferences-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { useSessionContext } from "@supabase/auth-helpers-react";
+
+import { useSupabaseContext } from "@/lib/supabase-context";
 
 interface NotificationPreferencesFormProps {
   initialPreferences: {
@@ -12,7 +13,7 @@ interface NotificationPreferencesFormProps {
 }
 
 export function NotificationPreferencesForm({ initialPreferences }: NotificationPreferencesFormProps) {
-  const { supabaseClient } = useSessionContext();
+  const { supabaseClient } = useSupabaseContext();
   const [email, setEmail] = useState(initialPreferences.email);
   const [sms, setSms] = useState(initialPreferences.sms);
   const [slackWebhook, setSlackWebhook] = useState(initialPreferences.slackWebhook);

--- a/app/(authenticated)/shipments/[id]/attachments/viewer.tsx
+++ b/app/(authenticated)/shipments/[id]/attachments/viewer.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useSessionContext } from "@supabase/auth-helpers-react";
+
+import { useSupabaseContext } from "@/lib/supabase-context";
 
 interface Attachment {
   id: string;
@@ -17,7 +18,7 @@ interface AttachmentManagerProps {
 }
 
 export function AttachmentManager({ shipmentId }: AttachmentManagerProps) {
-  const { supabaseClient } = useSessionContext();
+  const { supabaseClient } = useSupabaseContext();
   const queryClient = useQueryClient();
   const [uploading, setUploading] = useState(false);
 

--- a/app/(authenticated)/shipments/[id]/timeline.tsx
+++ b/app/(authenticated)/shipments/[id]/timeline.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useSessionContext } from "@supabase/auth-helpers-react";
+
+import { useSupabaseContext } from "@/lib/supabase-context";
 
 interface TimelineEvent {
   id: string;
@@ -32,7 +33,7 @@ interface ShipmentTimelineProps {
 }
 
 export function ShipmentTimeline({ shipmentId }: ShipmentTimelineProps) {
-  const { supabaseClient } = useSessionContext();
+  const { supabaseClient } = useSupabaseContext();
   const [accessToken, setAccessToken] = useState<string | null>(null);
 
   useEffect(() => {

--- a/lib/supabase-context.tsx
+++ b/lib/supabase-context.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
+
+interface SupabaseContextValue {
+  supabaseClient: SupabaseClient;
+  session: Session | null;
+}
+
+const SupabaseContext = createContext<SupabaseContextValue | undefined>(
+  undefined,
+);
+
+interface SupabaseProviderProps {
+  children: ReactNode;
+  initialSession: Session | null;
+  supabaseClient?: SupabaseClient;
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    "Missing Supabase environment variables. Ensure NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are set.",
+  );
+}
+
+export function SupabaseProvider({
+  children,
+  initialSession,
+  supabaseClient,
+}: SupabaseProviderProps) {
+  const [client] = useState<SupabaseClient>(() =>
+    supabaseClient ?? createBrowserClient(supabaseUrl, supabaseAnonKey),
+  );
+  const [session, setSession] = useState<Session | null>(initialSession);
+
+  useEffect(() => {
+    setSession(initialSession);
+  }, [initialSession]);
+
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = client.auth.onAuthStateChange((_event, newSession) => {
+      setSession(newSession);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [client]);
+
+  const value = useMemo(
+    () => ({
+      session,
+      supabaseClient: client,
+    }),
+    [client, session],
+  );
+
+  return (
+    <SupabaseContext.Provider value={value}>
+      {children}
+    </SupabaseContext.Provider>
+  );
+}
+
+export function useSupabaseContext() {
+  const context = useContext(SupabaseContext);
+
+  if (!context) {
+    throw new Error("useSupabaseContext must be used within a SupabaseProvider");
+  }
+
+  return context;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/auth-helpers-nextjs": "^0.10.0",
-        "@supabase/auth-helpers-react": "0.4.9",
         "@supabase/supabase-js": "^2.43.0",
         "next": "14.1.0",
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@supabase/auth-helpers-nextjs": "^0.10.0",
-    "@supabase/auth-helpers-react": "0.4.9",
     "@supabase/supabase-js": "^2.43.0",
     "@tanstack/react-query": "^5.32.1",
     "next": "14.1.0",


### PR DESCRIPTION
## Summary
- add a dedicated Supabase React context that manages the browser client and session state
- wrap the authenticated provider tree with the new SupabaseProvider and update consumers to use the new hook
- drop the @supabase/auth-helpers-react dependency and refresh the npm manifests

## Testing
- npm install *(fails: 403 Forbidden fetching @supabase/auth-helpers-nextjs due to registry policy)*

------
https://chatgpt.com/codex/tasks/task_e_68de6b89ec34832bb2f02f19adacf5f4