### PR TITLE
Use createPagesBrowserClient for Supabase

### DIFF
--- a/app/(authenticated)/providers.tsx
+++ b/app/(authenticated)/providers.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
+import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
 import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -24,7 +24,7 @@ if (!supabaseUrl || !supabaseAnonKey) {
 
 export function Providers({ children, initialSession }: ProvidersProps) {
   const [supabase] = useState<SupabaseClient>(() =>
-    createBrowserClient(supabaseUrl, supabaseAnonKey),
+    createPagesBrowserClient({ supabaseUrl, supabaseKey: supabaseAnonKey }),
   );
   const [queryClient] = useState(() => new QueryClient());
 

--- a/lib/supabase-context.tsx
+++ b/lib/supabase-context.tsx
@@ -6,7 +6,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
+import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
 import type { Session, SupabaseClient } from "@supabase/supabase-js";
 
 interface SupabaseContextValue {
@@ -39,7 +39,11 @@ export function SupabaseProvider({
   supabaseClient,
 }: SupabaseProviderProps) {
   const [client] = useState<SupabaseClient>(() =>
-    supabaseClient ?? createBrowserClient(supabaseUrl, supabaseAnonKey),
+    supabaseClient ??
+    createPagesBrowserClient({
+      supabaseUrl,
+      supabaseKey: supabaseAnonKey,
+    }),
   );
   const [session, setSession] = useState<Session | null>(initialSession);
 


### PR DESCRIPTION
## Summary
- replace the deprecated `createBrowserClient` helper with `createPagesBrowserClient` in the authenticated providers
- update the Supabase context to use the same helper while preserving the optional client override

## Testing
- npm run build *(fails: `next` binary not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6feab198832bbd4b16f11786e0e3