### PR TITLE
Refine Supabase browser client typing

### DIFF
--- a/app/(authenticated)/providers.tsx
+++ b/app/(authenticated)/providers.tsx
@@ -3,10 +3,13 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
-import type { Session, SupabaseClient } from "@supabase/supabase-js";
+import type { Session } from "@supabase/supabase-js";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { SupabaseProvider } from "@/lib/supabase-context";
+import {
+  SupabaseProvider,
+  type BrowserSupabaseClient,
+} from "@/lib/supabase-context";
 
 interface ProvidersProps {
   children: ReactNode;
@@ -23,7 +26,7 @@ if (!supabaseUrl || !supabaseAnonKey) {
 }
 
 export function Providers({ children, initialSession }: ProvidersProps) {
-  const [supabase] = useState<SupabaseClient>(() =>
+  const [supabase] = useState<BrowserSupabaseClient>(() =>
     createPagesBrowserClient({ supabaseUrl, supabaseKey: supabaseAnonKey }),
   );
   const [queryClient] = useState(() => new QueryClient());

--- a/lib/supabase-context.tsx
+++ b/lib/supabase-context.tsx
@@ -7,10 +7,12 @@ import {
   useState,
 } from "react";
 import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
-import type { Session, SupabaseClient } from "@supabase/supabase-js";
+import type { Session } from "@supabase/supabase-js";
+
+export type BrowserSupabaseClient = ReturnType<typeof createPagesBrowserClient>;
 
 interface SupabaseContextValue {
-  supabaseClient: SupabaseClient;
+  supabaseClient: BrowserSupabaseClient;
   session: Session | null;
 }
 
@@ -21,7 +23,7 @@ const SupabaseContext = createContext<SupabaseContextValue | undefined>(
 interface SupabaseProviderProps {
   children: ReactNode;
   initialSession: Session | null;
-  supabaseClient?: SupabaseClient;
+  supabaseClient?: BrowserSupabaseClient;
 }
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -38,7 +40,7 @@ export function SupabaseProvider({
   initialSession,
   supabaseClient,
 }: SupabaseProviderProps) {
-  const [client] = useState<SupabaseClient>(() =>
+  const [client] = useState<BrowserSupabaseClient>(() =>
     supabaseClient ??
     createPagesBrowserClient({
       supabaseUrl,


### PR DESCRIPTION
## Summary
- introduce a reusable BrowserSupabaseClient alias in the Supabase context
- apply the shared alias across the Supabase provider and authenticated providers

## Testing
- `npm run build` *(fails: next not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de71a89a00832bb4a633c8e00911a3