### PR TITLE
chore: type supabase clients with database schema

### DIFF
--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1,0 +1,39 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      notification_preferences: {
+        Row: {
+          id: number;
+          email: boolean;
+          sms: boolean;
+          slack_webhook: string | null;
+        };
+        Insert: {
+          id?: number;
+          email?: boolean;
+          sms?: boolean;
+          slack_webhook?: string | null;
+        };
+        Update: {
+          id?: number;
+          email?: boolean;
+          sms?: boolean;
+          slack_webhook?: string | null;
+        };
+        Relationships: [];
+      };
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+}

--- a/lib/supabase-context.tsx
+++ b/lib/supabase-context.tsx
@@ -7,9 +7,11 @@ import {
   useState,
 } from "react";
 import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
-import type { Session } from "@supabase/supabase-js";
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
 
-export type BrowserSupabaseClient = ReturnType<typeof createPagesBrowserClient>;
+import type { Database } from "./database.types";
+
+export type BrowserSupabaseClient = SupabaseClient<Database>;
 
 interface SupabaseContextValue {
   supabaseClient: BrowserSupabaseClient;
@@ -42,7 +44,7 @@ export function SupabaseProvider({
 }: SupabaseProviderProps) {
   const [client] = useState<BrowserSupabaseClient>(() =>
     supabaseClient ??
-    createPagesBrowserClient({
+    createPagesBrowserClient<Database>({
       supabaseUrl,
       supabaseKey: supabaseAnonKey,
     }),

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,4 +1,6 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "./database.types";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -11,13 +13,13 @@ if (!supabaseAnonKey) {
   throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable.");
 }
 
-const client = createClient(supabaseUrl, supabaseAnonKey, {
+const client = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   auth: {
     persistSession: true,
     autoRefreshToken: true,
   },
 });
 
-export const supabaseClient = client;
+export const supabaseClient: SupabaseClient<Database> = client;
 
 export default supabaseClient;


### PR DESCRIPTION
## Summary
- add a Supabase database schema definition covering notification preferences
- type the browser and shared Supabase clients with the schema so notification preference upserts are valid

## Testing
- npm run build *(fails: Next CLI unavailable in environment because dependencies cannot be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68de74fb078c832b8ae26b305c6a0650