### PR TITLE
fix: force node runtime for server modules

### DIFF
--- a/app/api/healthcheck/route.ts
+++ b/app/api/healthcheck/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 
+export const runtime = "nodejs";
+
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+export const runtime = "nodejs";
+
 export const metadata: Metadata = {
   title: "Supply Chain Toolkit",
   description: "Authenticated console for operations and configuration",


### PR DESCRIPTION
## Summary
- set the root layout to use the Node.js runtime so server components can rely on Node APIs
- ensure the healthcheck route handler opts into the Node.js runtime to avoid Edge bundling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0d2ea84e4832b8ff5c7f379c8a335